### PR TITLE
feat: dead letter queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ uv run python -c "import secrets; print(secrets.token_hex(32))"
 | `GET` | `/shims/{id}/logs/{log_id}` | Get a single log entry |
 | `GET` | `/shims/operators` | List valid rule operators |
 
+### Dead Letter Queue
+
+Failed forwards (non-2xx response or network error) are automatically written to a dead letter queue for inspection and replay.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dlq/` | List all DLQ entries across all shims (paginated) |
+| `GET` | `/dlq/{shim_id}` | List DLQ entries for a specific shim (paginated) |
+| `POST` | `/dlq/{dlq_id}/replay` | Replay a failed forward using its original payload, target URL, and headers |
+
+Each DLQ entry includes the original payload, target URL, rendered headers, failure status/error, and replay history (`replayed_at`, `replay_status`, `replay_error`). Replaying updates the entry in place — repeated replays overwrite the previous replay result.
+
 ### Metrics
 
 | Method | Path | Description |
@@ -269,6 +281,7 @@ app/
 └── routers/
     ├── auth.py          # Login, session check, token refresh
     ├── config.py        # GET/PATCH /config — application-wide settings
+    ├── dlq.py           # Dead letter queue — list and replay failed forwards
     ├── metrics.py       # GET /metrics/ — aggregate stats and time-series buckets
     ├── shims.py         # Shim, ShimRule, ShimVariable CRUD + test dry-run + logs
     └── webhooks.py      # Inbound webhook receiver (background forwarding)
@@ -288,6 +301,7 @@ tests/
 ├── test_templates.py    # Body/header template rendering integration tests
 ├── test_updates.py      # PATCH shim and rule tests
 ├── test_variables.py    # ShimVariable CRUD and cache invalidation tests
+├── test_dlq.py          # Dead letter queue creation, listing, and replay tests
 ├── test_metrics.py      # Metrics endpoint and bucketing tests
 ├── test_rate_limit.py   # Rate limiting enforcement tests
 └── test_webhooks.py     # Inbound webhook + signature verification tests

--- a/api/app/db/__init__.py
+++ b/api/app/db/__init__.py
@@ -16,6 +16,7 @@ from app.db.models import (
     AppConfig,
     AppConfigRead,
     AppConfigUpdate,
+    DeadLetter,
 )
 from app.db.engine import engine, init_db, get_session, AsyncSessionLocal
 
@@ -36,6 +37,7 @@ __all__ = [
     "AppConfig",
     "AppConfigRead",
     "AppConfigUpdate",
+    "DeadLetter",
     "engine",
     "init_db",
     "get_session",

--- a/api/app/db/models.py
+++ b/api/app/db/models.py
@@ -129,6 +129,23 @@ class WebhookLog(SQLModel, table=True):
     error: Optional[str] = None
 
 
+class DeadLetter(SQLModel, table=True):
+    __tablename__ = "dead_letter"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    shim_id: int = Field(foreign_key="shim.id", index=True)
+    webhook_log_id: Optional[int] = Field(default=None, foreign_key="webhook_log.id")
+    payload: str  # original request body
+    target_url: str
+    headers: str = Field(default="{}")  # rendered headers at time of failure
+    failed_at: datetime = Field(default_factory=now)
+    status: Optional[int] = None  # HTTP status (None = network error)
+    error: Optional[str] = None
+    replayed_at: Optional[datetime] = None
+    replay_status: Optional[int] = None
+    replay_error: Optional[str] = None
+
+
 class AppConfig(SQLModel, table=True):
     __tablename__ = "app_config"
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -13,6 +13,7 @@ from app.db import init_db, AsyncSessionLocal, AppConfig
 from app.logger import setup_logging, get_logger
 from app.routers import auth, shims, webhooks
 from app.routers import config as config_router
+from app.routers import dlq as dlq_router
 from app.routers import metrics as metrics_router
 
 logger = get_logger(__name__)
@@ -81,6 +82,7 @@ app.add_middleware(_DynamicCORSMiddleware)
 
 app.include_router(auth.router)
 app.include_router(config_router.router)
+app.include_router(dlq_router.router)
 app.include_router(metrics_router.router)
 app.include_router(shims.router)
 app.include_router(webhooks.router)

--- a/api/app/routers/dlq.py
+++ b/api/app/routers/dlq.py
@@ -1,0 +1,79 @@
+import json
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.auth import require_auth
+from app.db import get_session, Shim, DeadLetter
+from app.forwarder import forward
+from app.logger import get_logger
+from app.utils import now
+
+router = APIRouter(prefix="/dlq", tags=["dlq"], dependencies=[Depends(require_auth)])
+logger = get_logger(__name__)
+
+
+@router.get("/", response_model=list[DeadLetter])
+async def list_dlq(
+    limit: int = 50,
+    offset: int = 0,
+    session: AsyncSession = Depends(get_session),
+):
+    return (
+        await session.exec(
+            select(DeadLetter)
+            .order_by(DeadLetter.failed_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+    ).all()
+
+
+@router.get("/{shim_id}", response_model=list[DeadLetter])
+async def list_dlq_for_shim(
+    shim_id: int,
+    limit: int = 50,
+    offset: int = 0,
+    session: AsyncSession = Depends(get_session),
+):
+    if not await session.get(Shim, shim_id):
+        raise HTTPException(status_code=404, detail="Shim not found")
+    return (
+        await session.exec(
+            select(DeadLetter)
+            .where(DeadLetter.shim_id == shim_id)
+            .order_by(DeadLetter.failed_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+    ).all()
+
+
+@router.post("/{dlq_id}/replay", response_model=DeadLetter)
+async def replay(
+    dlq_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    entry = await session.get(DeadLetter, dlq_id)
+    if not entry:
+        raise HTTPException(status_code=404, detail="Dead letter entry not found")
+
+    headers = json.loads(entry.headers)
+    status_code, error = await forward(
+        entry.target_url, entry.payload.encode(), headers
+    )
+
+    entry.replayed_at = now()
+    entry.replay_status = status_code
+    entry.replay_error = error
+    session.add(entry)
+    await session.commit()
+    await session.refresh(entry)
+
+    if error:
+        logger.warning("dlq id=%d replay error: %s", dlq_id, error)
+    else:
+        logger.info("dlq id=%d replayed status=%s", dlq_id, status_code)
+
+    return entry

--- a/api/app/routers/webhooks.py
+++ b/api/app/routers/webhooks.py
@@ -7,7 +7,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app import app_config as _app_config
 from app import cache
 from app import rate_limit
-from app.db import get_session, Shim, ShimRule, ShimVariable, WebhookLog
+from app.db import get_session, Shim, ShimRule, ShimVariable, WebhookLog, DeadLetter
 from app.forwarder import (
     find_matching_rule,
     forward,
@@ -52,6 +52,8 @@ async def _forward_and_log(
         await session.commit()
         return
 
+    import json
+
     t0 = time.monotonic()
     status_code, error = await forward(target_url, forward_body, shim_headers)
     duration_ms = int((time.monotonic() - t0) * 1000)
@@ -68,6 +70,24 @@ async def _forward_and_log(
         error=error,
     )
     session.add(log)
+    await session.flush()  # populate log.id before referencing it
+
+    failed = error is not None or (
+        status_code is not None and not (200 <= status_code < 300)
+    )
+    if failed:
+        logger.warning("slug=%s adding to dead letter queue", slug)
+        session.add(
+            DeadLetter(
+                shim_id=shim_id,
+                webhook_log_id=log.id,
+                payload=raw_body.decode(),
+                target_url=target_url,
+                headers=json.dumps(shim_headers),
+                status=status_code,
+                error=error,
+            )
+        )
     await session.commit()
 
 

--- a/api/tests/test_dlq.py
+++ b/api/tests/test_dlq.py
@@ -1,0 +1,187 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def shim(client: TestClient, auth_headers):
+    return client.post(
+        "/shims/",
+        headers=auth_headers,
+        json={"name": "DLQ Shim", "slug": "dlq-shim", "target_url": "https://t.com"},
+    ).json()
+
+
+def _trigger(client: TestClient, status: int = 200, error: str | None = None):
+    return_value = (status, error)
+    with patch("app.routers.webhooks.forward", new_callable=AsyncMock) as mock_fwd:
+        mock_fwd.return_value = return_value
+        client.post("/in/dlq-shim", json={"event": "push"})
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_list_dlq_requires_auth(client: TestClient):
+    r = client.get("/dlq/")
+    assert r.status_code == 401
+
+
+def test_list_shim_dlq_requires_auth(client: TestClient, shim):
+    r = client.get(f"/dlq/{shim['id']}")
+    assert r.status_code == 401
+
+
+def test_replay_requires_auth(client: TestClient):
+    r = client.post("/dlq/1/replay")
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# DLQ creation
+# ---------------------------------------------------------------------------
+
+
+def test_non_2xx_creates_dlq_entry(client: TestClient, auth_headers, shim):
+    _trigger(client, status=500)
+    r = client.get(f"/dlq/{shim['id']}", headers=auth_headers)
+    assert r.status_code == 200
+    entries = r.json()
+    assert len(entries) == 1
+    assert entries[0]["status"] == 500
+    assert entries[0]["target_url"] == "https://t.com"
+    assert entries[0]["replayed_at"] is None
+
+
+def test_network_error_creates_dlq_entry(client: TestClient, auth_headers, shim):
+    _trigger(client, status=None, error="connection refused")
+    r = client.get(f"/dlq/{shim['id']}", headers=auth_headers)
+    entries = r.json()
+    assert len(entries) == 1
+    assert entries[0]["error"] == "connection refused"
+    assert entries[0]["status"] is None
+
+
+def test_2xx_does_not_create_dlq_entry(client: TestClient, auth_headers, shim):
+    _trigger(client, status=200)
+    r = client.get(f"/dlq/{shim['id']}", headers=auth_headers)
+    assert r.json() == []
+
+
+def test_multiple_failures_all_enqueued(client: TestClient, auth_headers, shim):
+    _trigger(client, status=502)
+    _trigger(client, status=503)
+    _trigger(client, status=404)
+    r = client.get(f"/dlq/{shim['id']}", headers=auth_headers)
+    assert len(r.json()) == 3
+
+
+# ---------------------------------------------------------------------------
+# Listing
+# ---------------------------------------------------------------------------
+
+
+def test_list_dlq_shim_not_found(client: TestClient, auth_headers):
+    r = client.get("/dlq/999", headers=auth_headers)
+    assert r.status_code == 404
+
+
+def test_list_dlq_global_returns_all_shims(client: TestClient, auth_headers):
+    shim_a = client.post(
+        "/shims/",
+        headers=auth_headers,
+        json={"name": "A", "slug": "dlq-a", "target_url": "https://t.com"},
+    ).json()
+    shim_b = client.post(
+        "/shims/",
+        headers=auth_headers,
+        json={"name": "B", "slug": "dlq-b", "target_url": "https://t.com"},
+    ).json()
+    with patch("app.routers.webhooks.forward", new_callable=AsyncMock) as mock_fwd:
+        mock_fwd.return_value = (500, None)
+        client.post("/in/dlq-a", json={})
+        client.post("/in/dlq-b", json={})
+    r = client.get("/dlq/", headers=auth_headers)
+    shim_ids = {e["shim_id"] for e in r.json()}
+    assert shim_a["id"] in shim_ids
+    assert shim_b["id"] in shim_ids
+
+
+def test_list_dlq_pagination(client: TestClient, auth_headers, shim):
+    for _ in range(5):
+        _trigger(client, status=500)
+    r1 = client.get(f"/dlq/{shim['id']}?limit=2&offset=0", headers=auth_headers)
+    r2 = client.get(f"/dlq/{shim['id']}?limit=2&offset=2", headers=auth_headers)
+    assert len(r1.json()) == 2
+    assert len(r2.json()) == 2
+    ids1 = {e["id"] for e in r1.json()}
+    ids2 = {e["id"] for e in r2.json()}
+    assert ids1.isdisjoint(ids2)
+
+
+# ---------------------------------------------------------------------------
+# Replay
+# ---------------------------------------------------------------------------
+
+
+def test_replay_successful(client: TestClient, auth_headers, shim):
+    _trigger(client, status=500)
+    entry = client.get(f"/dlq/{shim['id']}", headers=auth_headers).json()[0]
+
+    with patch("app.routers.dlq.forward", new_callable=AsyncMock) as mock_fwd:
+        mock_fwd.return_value = (200, None)
+        r = client.post(f"/dlq/{entry['id']}/replay", headers=auth_headers)
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["replay_status"] == 200
+    assert data["replay_error"] is None
+    assert data["replayed_at"] is not None
+
+
+def test_replay_failed(client: TestClient, auth_headers, shim):
+    _trigger(client, status=500)
+    entry = client.get(f"/dlq/{shim['id']}", headers=auth_headers).json()[0]
+
+    with patch("app.routers.dlq.forward", new_callable=AsyncMock) as mock_fwd:
+        mock_fwd.return_value = (None, "timeout")
+        r = client.post(f"/dlq/{entry['id']}/replay", headers=auth_headers)
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["replay_error"] == "timeout"
+    assert data["replayed_at"] is not None
+
+
+def test_replay_updates_in_place(client: TestClient, auth_headers, shim):
+    """Replaying the same entry twice should update, not duplicate."""
+    _trigger(client, status=500)
+    entry = client.get(f"/dlq/{shim['id']}", headers=auth_headers).json()[0]
+
+    with patch("app.routers.dlq.forward", new_callable=AsyncMock) as mock_fwd:
+        mock_fwd.return_value = (200, None)
+        client.post(f"/dlq/{entry['id']}/replay", headers=auth_headers)
+        mock_fwd.return_value = (201, None)
+        r = client.post(f"/dlq/{entry['id']}/replay", headers=auth_headers)
+
+    assert r.json()["replay_status"] == 201
+    # Still only one DLQ entry
+    assert len(client.get(f"/dlq/{shim['id']}", headers=auth_headers).json()) == 1
+
+
+def test_replay_not_found(client: TestClient, auth_headers):
+    r = client.post("/dlq/999/replay", headers=auth_headers)
+    assert r.status_code == 404
+
+
+def test_dlq_entry_links_to_webhook_log(client: TestClient, auth_headers, shim):
+    _trigger(client, status=500)
+    entry = client.get(f"/dlq/{shim['id']}", headers=auth_headers).json()[0]
+    log = client.get(
+        f"/shims/{shim['id']}/logs/{entry['webhook_log_id']}", headers=auth_headers
+    )
+    assert log.status_code == 200
+    assert log.json()["status"] == 500


### PR DESCRIPTION
## Summary
- Failed forwards (non-2xx or network error) are automatically written to a `dead_letter` table
- `GET /dlq/` and `GET /dlq/{shim_id}` for inspection (paginated)
- `POST /dlq/{id}/replay` re-forwards using the original payload, target URL, and rendered headers — updates the entry in place
- Each DLQ entry links back to its `webhook_log` entry via `webhook_log_id`

## Test plan
- [ ] Non-2xx response creates a DLQ entry
- [ ] Network error creates a DLQ entry  
- [ ] Successful 2xx does not create a DLQ entry
- [ ] Replay updates `replayed_at`, `replay_status`, `replay_error` in place
- [ ] Repeated replays overwrite previous replay result
- [ ] DLQ entry links to the correct webhook log
- [ ] All 174 tests passing

Closes #3