### PR TITLE
refactor: introduce BaseLayout so pages never import global.css directly

### DIFF
--- a/client/src/layouts/AppLayout.astro
+++ b/client/src/layouts/AppLayout.astro
@@ -1,5 +1,5 @@
 ---
-import '../styles/global.css';
+import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
   title: string;
@@ -8,60 +8,64 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width" />
-    <title>{title} — faf-shim</title>
-  </head>
-  <body class="bg-base-200 min-h-screen">
-    <div class="drawer lg:drawer-open">
-      <input id="drawer-toggle" type="checkbox" class="drawer-toggle" />
+<BaseLayout title={title}>
+  <div class="drawer lg:drawer-open bg-base-200 min-h-screen">
+    <input id="drawer-toggle" type="checkbox" class="drawer-toggle" />
 
-      <div class="drawer-content flex flex-col">
-        <!-- Mobile topbar -->
-        <div class="navbar bg-base-100 shadow lg:hidden">
-          <label for="drawer-toggle" class="btn btn-ghost drawer-button">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          </label>
-          <span class="text-lg font-bold ml-2">faf-shim</span>
-        </div>
-
-        <!-- Page content -->
-        <main class="p-6 flex-1">
-          <slot />
-        </main>
+    <div class="drawer-content flex flex-col">
+      <!-- Mobile topbar -->
+      <div class="navbar bg-base-100 shadow lg:hidden">
+        <label for="drawer-toggle" class="btn btn-ghost drawer-button">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 6h16M4 12h16M4 18h16"></path>
+          </svg>
+        </label>
+        <span class="text-lg font-bold ml-2">faf-shim</span>
       </div>
 
-      <!-- Sidebar -->
-      <div class="drawer-side">
-        <label for="drawer-toggle" class="drawer-overlay"></label>
-        <aside class="bg-base-100 w-60 min-h-full flex flex-col">
-          <div class="p-4 text-xl font-bold border-b border-base-200">faf-shim</div>
-          <ul class="menu flex-1 p-2 gap-1">
-            <li><a href="/shims">Shims</a></li>
-            <li><a href="/metrics">Metrics</a></li>
-            <li><a href="/dlq">Dead Letter Queue</a></li>
-            <li><a href="/config">Config</a></li>
-          </ul>
-          <div class="p-2 border-t border-base-200">
-            <button id="logout-btn" class="btn btn-ghost btn-sm w-full justify-start">Logout</button>
-          </div>
-        </aside>
-      </div>
+      <!-- Page content -->
+      <main class="p-6 flex-1">
+        <slot />
+      </main>
     </div>
 
-    <script>
-      import { requireAuth, clearToken } from '../lib/auth';
-      requireAuth();
+    <!-- Sidebar -->
+    <div class="drawer-side">
+      <label for="drawer-toggle" class="drawer-overlay"></label>
+      <aside class="bg-base-100 w-60 min-h-full flex flex-col">
+        <div class="p-4 text-xl font-bold border-b border-base-200">faf-shim</div>
+        <ul class="menu flex-1 p-2 gap-1">
+          <li><a href="/shims">Shims</a></li>
+          <li><a href="/metrics">Metrics</a></li>
+          <li><a href="/dlq">Dead Letter Queue</a></li>
+          <li><a href="/config">Config</a></li>
+        </ul>
+        <div class="p-2 border-t border-base-200">
+          <button id="logout-btn" class="btn btn-ghost btn-sm w-full justify-start"
+            >Logout</button
+          >
+        </div>
+      </aside>
+    </div>
+  </div>
 
-      document.getElementById('logout-btn')?.addEventListener('click', () => {
-        clearToken();
-        window.location.href = '/login';
-      });
-    </script>
-  </body>
-</html>
+  <script>
+    import { requireAuth, clearToken } from "../lib/auth";
+    requireAuth();
+
+    document.getElementById("logout-btn")?.addEventListener("click", () => {
+      clearToken();
+      window.location.href = "/login";
+    });
+  </script>
+</BaseLayout>

--- a/client/src/layouts/BaseLayout.astro
+++ b/client/src/layouts/BaseLayout.astro
@@ -1,0 +1,21 @@
+---
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{title} — faf-shim</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/client/src/pages/index.astro
+++ b/client/src/pages/index.astro
@@ -1,18 +1,10 @@
 ---
-import '../styles/global.css';
+import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width" />
-    <title>faf-shim</title>
-  </head>
-  <body>
-    <script>
-      import { isAuthenticated } from '../lib/auth';
-      window.location.href = isAuthenticated() ? '/shims' : '/login';
-    </script>
-  </body>
-</html>
+<BaseLayout title="faf-shim">
+  <script>
+    import { isAuthenticated } from "../lib/auth";
+    window.location.href = isAuthenticated() ? "/shims" : "/login";
+  </script>
+</BaseLayout>

--- a/client/src/pages/login.astro
+++ b/client/src/pages/login.astro
@@ -1,15 +1,9 @@
 ---
-import "../styles/global.css";
+import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Login — faf-shim</title>
-  </head>
-  <body class="bg-base-200 min-h-screen flex items-center justify-center">
+<BaseLayout title="Login">
+  <div class="bg-base-200 min-h-screen flex items-center justify-center">
     <div class="card bg-base-100 shadow-md w-full max-w-sm">
       <div class="card-body gap-4">
         <h1 class="card-title text-2xl">faf-shim</h1>
@@ -49,53 +43,53 @@ import "../styles/global.css";
         </form>
       </div>
     </div>
+  </div>
 
-    <script>
-      import { isAuthenticated, setToken } from "../lib/auth";
+  <script>
+    import { isAuthenticated, setToken } from "../lib/auth";
 
-      if (isAuthenticated()) {
-        window.location.href = "/shims";
-      }
+    if (isAuthenticated()) {
+      window.location.href = "/shims";
+    }
 
-      const form = document.getElementById("login-form") as HTMLFormElement;
-      const submitBtn = document.getElementById("submit-btn") as HTMLButtonElement;
-      const errorAlert = document.getElementById("error-alert") as HTMLDivElement;
-      const errorMsg = document.getElementById("error-msg") as HTMLSpanElement;
+    const form = document.getElementById("login-form") as HTMLFormElement;
+    const submitBtn = document.getElementById("submit-btn") as HTMLButtonElement;
+    const errorAlert = document.getElementById("error-alert") as HTMLDivElement;
+    const errorMsg = document.getElementById("error-msg") as HTMLSpanElement;
 
-      const BASE_URL = import.meta.env.PUBLIC_API_URL ?? "http://localhost:8000";
+    const BASE_URL = import.meta.env.PUBLIC_API_URL ?? "http://localhost:8000";
 
-      form.addEventListener("submit", async (e) => {
-        e.preventDefault();
-        errorAlert.classList.add("hidden");
-        submitBtn.classList.add("loading");
-        submitBtn.disabled = true;
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      errorAlert.classList.add("hidden");
+      submitBtn.classList.add("loading");
+      submitBtn.disabled = true;
 
-        const username = (document.getElementById("username") as HTMLInputElement).value;
-        const password = (document.getElementById("password") as HTMLInputElement).value;
+      const username = (document.getElementById("username") as HTMLInputElement).value;
+      const password = (document.getElementById("password") as HTMLInputElement).value;
 
-        try {
-          const res = await fetch(`${BASE_URL}/auth/login`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ username, password }),
-          });
+      try {
+        const res = await fetch(`${BASE_URL}/auth/login`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username, password }),
+        });
 
-          if (!res.ok) {
-            const data = await res.json().catch(() => ({}));
-            throw new Error(data.detail ?? "Login failed");
-          }
-
-          const { access_token } = await res.json();
-          setToken(access_token);
-          window.location.href = "/shims";
-        } catch (err) {
-          errorMsg.textContent = err instanceof Error ? err.message : "Login failed";
-          errorAlert.classList.remove("hidden");
-        } finally {
-          submitBtn.classList.remove("loading");
-          submitBtn.disabled = false;
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.detail ?? "Login failed");
         }
-      });
-    </script>
-  </body>
-</html>
+
+        const { access_token } = await res.json();
+        setToken(access_token);
+        window.location.href = "/shims";
+      } catch (err) {
+        errorMsg.textContent = err instanceof Error ? err.message : "Login failed";
+        errorAlert.classList.remove("hidden");
+      } finally {
+        submitBtn.classList.remove("loading");
+        submitBtn.disabled = false;
+      }
+    });
+  </script>
+</BaseLayout>


### PR DESCRIPTION
## Summary

- Adds `src/layouts/BaseLayout.astro` — owns the HTML shell, head tags, and `global.css` import
- `AppLayout` now wraps `BaseLayout` instead of duplicating the shell
- `login.astro` and `index.astro` use `BaseLayout` directly
- No page imports `global.css` anymore — it flows through the layout