### PR TITLE
chore: add .env.example for PUBLIC_API_URL

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+# URL of the faf-shim API server (baked in at build time)
+PUBLIC_API_URL=http://localhost:8000


### PR DESCRIPTION
Documents the `PUBLIC_API_URL` env variable that must be set before building the client. The variable is baked in at build time by Astro's static output. `.env` is already in `.gitignore`.