### PR TITLE
chore: add lint and format scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,10 @@ jobs:
         run: bun install
 
       - name: Oxlint
-        run: bunx oxlint
+        run: bun run lint
 
       - name: Oxfmt check
-        run: bunx oxfmt --check
+        run: bun run format:check
 
       - name: Build
         run: bun run build

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,10 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "lint": "oxlint",
+    "format": "oxfmt",
+    "format:check": "oxfmt --check"
   },
   "dependencies": {
     "@astrojs/react": "^5.0.1",


### PR DESCRIPTION
- Adds `lint`, `format`, and `format:check` scripts to `client/package.json`
- Updates CI to use `bun run lint` and `bun run format:check` instead of `bunx` directly