### PR TITLE
chore: set DaisyUI theme to coffee

### DIFF
--- a/client/src/layouts/BaseLayout.astro
+++ b/client/src/layouts/BaseLayout.astro
@@ -8,7 +8,7 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<html lang="en">
+<html lang="en" data-theme="coffee">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -1,2 +1,4 @@
 @import "tailwindcss";
-@plugin "daisyui";
+@plugin "daisyui" {
+  themes: coffee;
+}


### PR DESCRIPTION
Sets the coffee theme globally via the DaisyUI plugin config and `data-theme` on the html element.