### PR TITLE
chore: expand Makefile with dev, hash-password, and gen-secret targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,7 @@ Interactive API docs available at `/docs` when running locally.
 ```bash
 cp .env.example .env
 # Fill in ADMIN_PASSWORD_HASH and JWT_SECRET in .env
-uv sync
-uv run fastapi dev app/main.py
+make dev
 ```
 
 The SQLite database (`faf-shim.db`) is created automatically on first run with WAL mode enabled.
@@ -258,7 +257,15 @@ The SQLite database (`faf-shim.db`) is created automatically on first run with W
 Tests use an in-memory SQLite database — nothing touches the real `faf-shim.db`.
 
 ```bash
-uv run pytest tests/ -v
+make test
+```
+
+### Linting & Formatting
+
+```bash
+make lint    # ruff check
+make format  # ruff format
+make check   # lint + test
 ```
 
 ---

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint format check
+.PHONY: test lint format check dev hash-password gen-secret
 
 test:
 	uv run pytest tests/ -v
@@ -9,4 +9,14 @@ lint:
 format:
 	uvx ruff format
 
+dev:
+	uv sync
+	uv run uvicorn app.main:app --reload
+
 check: lint test
+
+hash-password:
+	@read -p "Password: " pw && uv run python -c "import bcrypt; print(bcrypt.hashpw(pw.encode(), bcrypt.gensalt()).decode())"
+
+gen-secret:
+	uv run python -c "import secrets; print(secrets.token_hex(32))"


### PR DESCRIPTION
## Summary
- Adds `make dev` target (replaces `uv run fastapi dev`, uses uvicorn directly)
- Adds `make hash-password` target (prompts for password, prints bcrypt hash)
- Adds `make gen-secret` target (prints a random 32-byte hex JWT secret)
- Updates README development section to use `make` commands throughout