### PR TITLE
feat: Dockerfile and docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+**/.venv
+**/__pycache__
+**/*.pyc
+**/*.db
+**/*.db-shm
+**/*.db-wal
+**/node_modules
+**/dist
+**/.env

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,9 @@
+.venv
+__pycache__
+*.pyc
+*.db
+*.db-shm
+*.db-wal
+.env
+tests
+logs

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.14-slim
+
+WORKDIR /app
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Install dependencies (cached layer)
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+# Copy application code
+COPY . .
+
+# SQLite data lives in a volume at /data
+RUN mkdir -p /data
+ENV DATABASE_URL=sqlite+aiosqlite:////data/faf-shim.db
+
+EXPOSE 8000
+
+CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/app/db/engine.py
+++ b/api/app/db/engine.py
@@ -1,10 +1,11 @@
+import os
 from collections.abc import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel, text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-DATABASE_URL = "sqlite+aiosqlite:///faf-shim.db"
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///faf-shim.db")
 
 engine = create_async_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,3 @@
+.env
+dist
+node_modules

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+# Install bun
+RUN npm install -g bun
+
+# Install dependencies (cached layer)
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+# Copy source and build
+# PUBLIC_API_URL is baked in at build time — override via --build-arg
+ARG PUBLIC_API_URL=http://localhost:8000
+ENV PUBLIC_API_URL=$PUBLIC_API_URL
+
+COPY . .
+RUN bun run build
+
+# Serve with nginx
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Clean default config and use a minimal one
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Serve static files; fall back to index.html for client-side routing
+    location / {
+        try_files $uri $uri/ $uri.html /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  api:
+    build: ./api
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    volumes:
+      - db_data:/data
+    environment:
+      - DATABASE_URL=sqlite+aiosqlite:////data/faf-shim.db
+      - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
+      - ADMIN_PASSWORD_HASH=${ADMIN_PASSWORD_HASH}
+      - JWT_SECRET=${JWT_SECRET}
+    env_file:
+      - path: .env
+        required: false
+
+  web:
+    build:
+      context: ./client
+      args:
+        PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8000}
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    depends_on:
+      - api
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- `api/Dockerfile` — Python 3.14-slim with uv, SQLite volume at `/data`, uvicorn on port 8000
- `client/Dockerfile` — Node 22 + bun build stage, nginx serve stage; `PUBLIC_API_URL` configurable as build arg
- `client/nginx.conf` — static file serving with asset caching
- `docker-compose.yml` — wires api + web, SQLite volume, env var passthrough for credentials
- `api/app/db/engine.py` — `DATABASE_URL` now reads from env (defaults to local path for dev)

## Usage
```sh
cp api/.env.example api/.env  # set ADMIN_PASSWORD_HASH, JWT_SECRET
docker compose up --build
```

Closes #6