### PR TITLE
fix: remove port bindings for Coolify

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ services:
   api:
     build: ./api
     restart: unless-stopped
-    ports:
-      - "8000:8000"
     volumes:
       - db_data:/data
     environment:
@@ -21,8 +19,6 @@ services:
       args:
         PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8000}
     restart: unless-stopped
-    ports:
-      - "80:80"
     depends_on:
       - api
 


### PR DESCRIPTION
Remove hardcoded port bindings (8000, 80) from docker-compose. Coolify routes traffic via Traefik proxy so binding ports directly conflicts with other services on the host.