### PR TITLE
fix: Docker deployment fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,17 +236,61 @@ Interactive API docs available at `/docs` when running locally.
 
 ---
 
+## Deployment
+
+### Docker (recommended)
+
+```bash
+# 1. Copy and fill in credentials
+cp api/.env.example api/.env
+
+# Generate a password hash
+uv run python -c "import bcrypt; print(bcrypt.hashpw(b'yourpassword', bcrypt.gensalt()).decode())"
+
+# Generate a JWT secret
+uv run python -c "import secrets; print(secrets.token_hex(32))"
+
+# 2. Set your API URL (used at client build time)
+export PUBLIC_API_URL=http://your-api-domain:8000
+
+# 3. Build and run
+docker compose up --build
+```
+
+The client is served on port `80` and the API on port `8000` by default. Override with env vars:
+
+```bash
+API_PORT=9000 WEB_PORT=8080 docker compose up
+```
+
+SQLite data is persisted in a Docker volume (`db_data`).
+
+### Coolify
+
+Deploy as a Docker Compose application. Set the following environment variables in Coolify before deploying:
+
+| Variable | Description |
+|----------|-------------|
+| `ADMIN_PASSWORD_HASH` | bcrypt hash of your admin password (wrap in single quotes) |
+| `JWT_SECRET` | Long random string for signing JWTs |
+| `PUBLIC_API_URL` | Full URL of the API service as seen by browsers |
+
+Coolify handles routing via its Traefik proxy — assign a domain to each service (`web` and `api`) in the Coolify UI.
+
+---
+
 ## Development
 
 ### Requirements
-- Python 3.11+
+- Python 3.14+
 - [uv](https://github.com/astral-sh/uv)
+- Node 22+, [bun](https://bun.sh)
 
 ### Setup
 
 ```bash
-cp .env.example .env
-# Fill in ADMIN_PASSWORD_HASH and JWT_SECRET in .env
+cp api/.env.example api/.env
+# Fill in ADMIN_PASSWORD_HASH and JWT_SECRET in api/.env
 make dev
 ```
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,7 +1,9 @@
 # Generate a password hash with:
-#   uv run python -c "from passlib.context import CryptContext; print(CryptContext(schemes=['bcrypt']).hash('yourpassword'))"
+#   uv run python -c "import bcrypt; print(bcrypt.hashpw(b'yourpassword', bcrypt.gensalt()).decode())"
+# IMPORTANT: wrap the hash in single quotes to prevent Docker Compose from
+# interpreting the $ characters in the bcrypt hash as variable references.
 ADMIN_USERNAME=admin
-ADMIN_PASSWORD_HASH=
+ADMIN_PASSWORD_HASH=''
 
 # Generate a secret with:
 #   uv run python -c "import secrets; print(secrets.token_hex(32))"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -18,4 +18,4 @@ ENV DATABASE_URL=sqlite+aiosqlite:////data/faf-shim.db
 
 EXPOSE 8000
 
-CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,14 @@ services:
   api:
     build: ./api
     restart: unless-stopped
+    ports:
+      - "${API_PORT:-8000}:8000"
     volumes:
       - db_data:/data
     environment:
       - DATABASE_URL=sqlite+aiosqlite:////data/faf-shim.db
-      - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
-      - ADMIN_PASSWORD_HASH=${ADMIN_PASSWORD_HASH}
-      - JWT_SECRET=${JWT_SECRET}
     env_file:
-      - path: .env
+      - path: ./api/.env
         required: false
 
   web:
@@ -19,6 +18,8 @@ services:
       args:
         PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8000}
     restart: unless-stopped
+    ports:
+      - "${WEB_PORT:-80}:80"
     depends_on:
       - api
 


### PR DESCRIPTION
## Summary
- Fix uvicorn entrypoint from `main:app` to `app.main:app`
- Fix `env_file` path to `./api/.env` (was looking in wrong directory)
- Add configurable port bindings via `API_PORT` and `WEB_PORT` env vars (defaults: 8000, 80)
- Update `api/.env.example` to warn about wrapping bcrypt hash in single quotes to prevent Docker Compose `$` interpolation
- Update README with Docker and Coolify deployment instructions