### PR TITLE
fix: use expose instead of ports, add override file for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,6 @@ Interactive API docs available at `/docs` when running locally.
 # 1. Copy and fill in credentials
 cp api/.env.example api/.env
 
-# Generate a password hash
-uv run python -c "import bcrypt; print(bcrypt.hashpw(b'yourpassword', bcrypt.gensalt()).decode())"
-
-# Generate a JWT secret
-uv run python -c "import secrets; print(secrets.token_hex(32))"
-
 # 2. Set your API URL (used at client build time)
 export PUBLIC_API_URL=http://your-api-domain:8000
 
@@ -254,7 +248,7 @@ export PUBLIC_API_URL=http://your-api-domain:8000
 docker compose up --build
 ```
 
-The client is served on port `80` and the API on port `8000` by default. Override with env vars:
+`docker-compose.override.yml` is included and binds the API to port `8000` and the web to port `80` by default for local use. Override with env vars:
 
 ```bash
 API_PORT=9000 WEB_PORT=8080 docker compose up

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,8 @@
+services:
+  api:
+    ports:
+      - "${API_PORT:-8000}:8000"
+
+  web:
+    ports:
+      - "${WEB_PORT:-80}:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,16 @@ services:
   api:
     build: ./api
     restart: unless-stopped
-    ports:
-      - "${API_PORT:-8000}:8000"
+    expose:
+      - "8000"
     volumes:
       - db_data:/data
     environment:
       - DATABASE_URL=sqlite+aiosqlite:////data/faf-shim.db
+      - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
+      - JWT_SECRET=${JWT_SECRET:-}
+      - JWT_EXPIRE_MINUTES=${JWT_EXPIRE_MINUTES:-60}
     env_file:
       - path: ./api/.env
         required: false
@@ -18,8 +22,8 @@ services:
       args:
         PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8000}
     restart: unless-stopped
-    ports:
-      - "${WEB_PORT:-80}:80"
+    expose:
+      - "80"
     depends_on:
       - api
 


### PR DESCRIPTION
## Summary
- Replace `ports:` with `expose:` in `docker-compose.yml` — Coolify routes via Traefik and host port bindings conflict with other services on the same server
- Add `docker-compose.override.yml` for local development — Docker Compose auto-loads this, so `docker compose up` still binds ports 8000/80 locally
- Add `ADMIN_PASSWORD`, `JWT_SECRET`, and other auth vars to the `environment:` block so Coolify surfaces them in its env vars dashboard

## Test plan
- [x] `docker compose up --build` locally — API accessible on :8000, web on :80 (via override)
- [x] Deploy to Coolify — no port conflict, Traefik handles routing via assigned domain