### PR TITLE
fix: log response body for non-2xx forward responses

### DIFF
--- a/api/app/forwarder.py
+++ b/api/app/forwarder.py
@@ -82,6 +82,8 @@ async def forward(
     try:
         async with httpx.AsyncClient() as client:
             r = await client.post(target_url, content=body, headers=headers, timeout=10)
+            if not (200 <= r.status_code < 300):
+                return r.status_code, r.text
             return r.status_code, None
     except Exception as e:
         return None, str(e)


### PR DESCRIPTION
## Summary

- `forward()` previously returned `(status_code, None)` for all non-exception responses, even on 4xx/5xx
- Non-2xx responses now return `(status_code, r.text)` so the response body surfaces as the error
- This flows into existing logging in `webhooks.py` (`logger.error`) and `dlq.py` (`logger.warning`), and is stored in `WebhookLog.error` and `DeadLetter.replay_error`

## Test plan

- [ ] Trigger a webhook that forwards to a URL returning 4xx/5xx — confirm the response body appears in the log entry's `error` field
- [ ] Replay a DLQ entry against a failing endpoint — confirm `replay_error` is populated with the response body
- [ ] Successful forwards (2xx) still have `error = None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)